### PR TITLE
expand resize interface to support multiple filter type

### DIFF
--- a/ext/rfreeimage/rfi_main.c
+++ b/ext/rfreeimage/rfi_main.c
@@ -417,19 +417,23 @@ VALUE Image_clone(VALUE self)
 	return rfi_get_image(nh);
 }
 
-VALUE Image_resize(VALUE self, VALUE dst_width, VALUE dst_height)
+VALUE Image_rescale(VALUE self, VALUE dst_width, VALUE dst_height, VALUE filter_type)
 {
 	struct native_image *img;
 	FIBITMAP *nh;
 	int w = NUM2INT(dst_width);
 	int h = NUM2INT(dst_height);
+	int f = NUM2INT(filter_type);
 	if (w <= 0 || h <= 0)
 		rb_raise(rb_eArgError, "Invalid size");
+
+	if (f < FILTER_BOX || f > FILTER_LANCZOS3)
+		rb_raise(rb_eArgError, "Invalid image filter type");
 
 	Data_Get_Struct(self, struct native_image, img);
 	RFI_CHECK_IMG(img);
 
-	nh = FreeImage_Rescale(img->handle, w, h, FILTER_CATMULLROM);
+	nh = FreeImage_Rescale(img->handle, w, h, f);
 	return rfi_get_image(nh);
 }
 
@@ -630,7 +634,7 @@ void Init_rfreeimage(void)
 
 	rb_define_method(Class_Image, "to_bpp", Image_to_bpp, 1);
 	rb_define_method(Class_Image, "rotate", Image_rotate, 1);
-	rb_define_method(Class_Image, "resize", Image_resize, 2);
+	rb_define_method(Class_Image, "rescale", Image_rescale, 3);
 	rb_define_method(Class_Image, "crop", Image_crop, 4);
 	rb_define_method(Class_Image, "to_blob", Image_to_blob, 1);
 

--- a/lib/rfreeimage/image.rb
+++ b/lib/rfreeimage/image.rb
@@ -14,6 +14,14 @@ module RFreeImage
 		BLACK   = 0xff000000
 		GRAY    = 0xffa9a9a9
 	end
+	module Filter
+		FILTER_BOX = 0
+		FILTER_BICUBIC = 1
+		FILTER_BILINEAR = 2
+		FILTER_BSPLINE = 3
+		FILTER_CATMULLROM = 4
+		FILTER_LANCZOS3 = 5
+	end
 	class Image
 		def bytes
 			@bytes ||= read_bytes
@@ -40,6 +48,10 @@ module RFreeImage
 		def to_bgra
 			return self if bgra?
 			to_bpp 32
+		end
+
+		def resize(width, height, filter = Filter::FILTER_CATMULLROM)
+			return self.rescale(width, height, filter)
 		end
 
 

--- a/lib/rfreeimage/version.rb
+++ b/lib/rfreeimage/version.rb
@@ -1,3 +1,3 @@
 module RFreeImage
-	VERSION = '0.1.5'
+	VERSION = '0.1.6'
 end

--- a/test/image_test.rb
+++ b/test/image_test.rb
@@ -194,3 +194,33 @@ class TestFromBytes < Test::Unit::TestCase
   end
 end
 
+class TestResizeFilter < Test::Unit::TestCase
+	def setup
+		@img = Image.new get_image("test.jpg")
+		@w = @img.cols
+		@h = @img.rows
+	end
+
+	def test_invalid_filter
+		assert_raise do
+			rimg1 = @img.resize @w * 2, @h * 2, -1
+		end
+
+		assert_raise do
+			rimg1 = @img.resize @w * 2, @h * 2, 6
+		end
+	end
+
+	def test_default_filter
+		rimg = @img.resize @w * 2, @h * 2
+		cimg = @img.resize @w * 2, @h * 2, Filter::FILTER_CATMULLROM
+		assert_equal rimg.format, "BMP"
+		assert_equal rimg.bytes, cimg.bytes
+	end
+
+	def test_bilinear_filter
+		rimg = @img.resize @w * 2, @h * 2, Filter::FILTER_BILINEAR
+		assert_equal rimg.format, "BMP"
+	end
+
+end


### PR DESCRIPTION
1. rename rfi method "resize" to "rescale", add parameter "filter_type"
2. add method "resize" with default filter "CATMULLROM" in RFreeImage::Image
3. add unittest for resize filter
4. update version number to "0.1.6"
